### PR TITLE
Native rgba

### DIFF
--- a/src/athena.c
+++ b/src/athena.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]){
     struct Athena_Options option;
     const int err1 = Athena_LoadOptions(athena_default_settings_path, &option);
     struct Athena_Window * const window = Athena_CreateWindow(option.screen_w, option.screen_h, "Athena Hotseat Test");
-    struct Athena_Player players[] = {{{0, 0, 0}, "Flying Jester", {NULL, 0, 0}, 0xFF0000FF, 1}, {{0, 0, 0}, "Iron XIII", {NULL, 0, 0}, 0xFFF00FF0, 1}};
+    struct Athena_Player players[] = {{{0, 0, 0}, "Flying Jester", {NULL, 0, 0}, 0xFFFF0000, 1}, {{0, 0, 0}, "Iron XIII", {NULL, 0, 0}, 0xFFF00FF0, 1}};
     struct Athena_Field field;
 
     struct Athena_Sound *sound = Athena_LoadOpusFile("res/sounds/night_at_the_river.opus");

--- a/src/athena_camera_test.c
+++ b/src/athena_camera_test.c
@@ -24,7 +24,7 @@ int main(int argc, char *argv[]){
     struct Athena_Options option;
     const int err1 = Athena_LoadOptions("athena_settings.json", &option);
     struct Athena_Window * const window = Athena_CreateWindow(option.screen_w, option.screen_h, "Athena Test");
-    struct Athena_Player players[] = {{{0, 0, 0}, "Flying Jester", {NULL, 0, 0}, 0xFF0000FF}, {{0, 0, 0}, "Link", {NULL, 0, 0}, 0xFF0FF0F0}};
+    struct Athena_Player players[] = {{{0, 0, 0}, "Flying Jester", {NULL, 0, 0}, 0xFFFF0000}, {{0, 0, 0}, "Link", {NULL, 0, 0}, 0xFF0FF0F0}};
     struct Athena_Field field;
 
     if(err1){}

--- a/src/athena_unit_test.c
+++ b/src/athena_unit_test.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]){
     struct Athena_Options option;
     const int err1 = Athena_LoadOptions("athena_settings.json", &option);
     struct Athena_Window * const window = Athena_CreateWindow(option.screen_w, option.screen_h, "Athena Test");
-    struct Athena_Player players[] = {{{0, 0, 0}, "Flying Jester", {NULL, 0, 0}, 0xFF0000FF, 1}, {{0, 0, 0}, "Link", {NULL, 0, 0}, 0xFF0FF0F0, 1}};
+    struct Athena_Player players[] = {{{0, 0, 0}, "Flying Jester", {NULL, 0, 0}, 0xFFFF0000, 1}, {{0, 0, 0}, "Link", {NULL, 0, 0}, 0xFF0FF0F0, 1}};
     struct Athena_Field field;
 
     struct Athena_Sound *sound = Athena_LoadOpusFile("res/sounds/night_at_the_river.opus");

--- a/src/image.c
+++ b/src/image.c
@@ -352,21 +352,21 @@ const uint32_t *Athena_PixelConst(const struct Athena_Image *to, int x, int y){
 /* 0xFF00FFFF is yellow. That is all. */
 
 uint32_t Athena_RGBAToRaw(uint8_t r, uint8_t g, uint8_t b, uint8_t a){
-    return (a << 24) | (b << 16) | (g << 8) | (r);
+    return (a << 24) | (r << 16) | (g << 8) | (b);
 }
 
 void Athena_RawToRGBA(uint32_t rgba, uint8_t *r, uint8_t *g, uint8_t *b, uint8_t *a){
-    r[0] = rgba & 0xFF;
+    b[0] = rgba & 0xFF;
     rgba >>= 8;
     g[0] = rgba & 0xFF;
     rgba >>= 8;
-    b[0] = rgba & 0xFF;
+    r[0] = rgba & 0xFF;
     rgba >>= 8;
     a[0] = rgba & 0xFF;
 }
 
 uint8_t Athena_RawToR(uint32_t rgba){
-    return rgba & 0xFF;
+    return (rgba >> 16) & 0xFF;
 }
 
 uint8_t Athena_RawToG(uint32_t rgba){
@@ -374,7 +374,7 @@ uint8_t Athena_RawToG(uint32_t rgba){
 }
 
 uint8_t Athena_RawToB(uint32_t rgba){
-    return (rgba >> 16) & 0xFF;
+    return rgba & 0xFF;
 }
 
 uint8_t Athena_RawToA(uint32_t rgba){

--- a/src/load_png.c
+++ b/src/load_png.c
@@ -115,17 +115,39 @@ start_row:
                 row_mem = row_buf;
                 
                 memcpy(row_mem, row_p, to->w * 3);
+start_pixel_color_alpha_mux:
+/*                memcpy(row_p, row_mem, 3); */
 
-start_pixel_mux:
-                memcpy(row_p, row_mem, 3);
+                row_p[2] = row_mem[0];
+                row_p[1] = row_mem[1];
+                row_p[0] = row_mem[2];
+
                 row_p += 3;
                 row_mem += 3;
-                    
+
                 row_p[0] = 0xFF;
                 row_p++;
 
                 if(++w<to->w)
-                    goto start_pixel_mux;
+                    goto start_pixel_color_alpha_mux;
+            }
+            else{
+                int w = 0;
+                char r, g, b;
+start_pixel_color_mux:
+                
+                b = row_p[0];
+                g = row_p[1];
+                r = row_p[2];
+                
+                row_p[0] = r;
+                row_p[1] = g;
+                row_p[2] = b;
+
+                row_p += 4;
+
+                if(++w<to->w)
+                    goto start_pixel_color_mux;
             }
         }
         if(++h < to->h)

--- a/src/load_tga.c
+++ b/src/load_tga.c
@@ -82,12 +82,12 @@ static uint8_t athena_read_tga_16(uint32_t *to, const uint8_t *from){
 }
 
 static uint8_t athena_read_tga_24(uint32_t *to, const uint8_t *from){
-    to[0] = Athena_RGBAToRaw(from[2], from[1], from[0], 0xFF);
+    to[0] = Athena_RGBAToRaw(from[0], from[1], from[2], 0xFF);
     return 3;
 }
 
 static uint8_t athena_read_tga_32(uint32_t *to, const uint8_t *from){
-    to[0] = Athena_RGBAToRaw(from[2], from[1], from[0], from[3]);
+    to[0] = Athena_RGBAToRaw(from[0], from[1], from[2], from[3]);
     return 4;
 }
 

--- a/src/platform/window/window_sdl.c
+++ b/src/platform/window/window_sdl.c
@@ -57,9 +57,9 @@ int Athena_Private_HideWindow(void *handle){
 
 static SDL_Surface *Athena_Private_SurfaceOfFormat(unsigned w, unsigned h, unsigned format, const void *RGB){
 const unsigned long
-    r0 = 0x000000FF,
+    r0 = 0x00FF0000,
     g0 = 0x0000FF00,
-    b0 = 0x00FF0000,
+    b0 = 0x000000FF,
     a0 = 0xFF000000,
     r1 = 0x0000FF00,
     g1 = 0x00FF0000,

--- a/src/platform/window/window_x11.c
+++ b/src/platform/window/window_x11.c
@@ -194,6 +194,8 @@ int Athena_Private_Update(void *handle, unsigned format, const void *RGBA, unsig
         memcpy(x_window->shminfo.shmaddr, RGBA, w * h << 2);
     }
     else if(athena_x11_visinfo(x_window)->depth==24){
+        memcpy(x_window->shminfo.shmaddr, RGBA, w * h << 2);
+/*
         unsigned i;
         const unsigned num_pixels = w * h;
         const unsigned int *in = RGBA;
@@ -203,6 +205,7 @@ int Athena_Private_Update(void *handle, unsigned format, const void *RGBA, unsig
             pixel[1] = (in[i] >> 8) & 0xFF;
             pixel[0] = (in[i] >> 16) & 0xFF;
         }
+*/
     }
     else{
         memcpy(x_window->shminfo.shmaddr, RGBA, w * h * athena_x11_visinfo(x_window)->depth >> 3);


### PR DESCRIPTION
This swaps byte order of images to:

a: 0xFF000000
r: 0x00FF0000
g: 0x0000FF00
b: 0x000000FF

This lines up with the native X11 and Haiku byte orders when pushing 24 an 32-bit graphics to the screen. We could ideally make this switchable at run time, or just by chosen platform, however we have yet to target a platform with a different 24/32 bit graphics byte order. Additionally, this branch has proven that the only places with hardcoded RGBA byte order outside the actual conversion functions in image.c are in the image loaders themselves.
